### PR TITLE
Add extended version for fetching upcoming matches

### DIFF
--- a/api/scrape.py
+++ b/api/scrape.py
@@ -7,6 +7,7 @@ from api.scrapers import (
     vlr_rankings,
     vlr_stats,
     vlr_upcoming_matches,
+    vlr_upcoming_matches_extended,
 )
 
 
@@ -34,6 +35,10 @@ class Vlr:
     @staticmethod
     def vlr_match_results(num_pages=1, from_page=None, to_page=None, max_retries=3, request_delay=1.0, timeout=30):
         return vlr_match_results(num_pages, from_page, to_page, max_retries, request_delay, timeout)
+
+    @staticmethod
+    def vlr_upcoming_matches_extended(num_pages=1, from_page=None, to_page=None, max_retries=3, request_delay=1.0, timeout=30):
+        return vlr_upcoming_matches_extended(num_pages, from_page, to_page, max_retries, request_delay, timeout)
 
     @staticmethod
     def vlr_events(upcoming=True, completed=True, page=1):

--- a/api/scrapers/__init__.py
+++ b/api/scrapers/__init__.py
@@ -1,6 +1,6 @@
 from .news import vlr_news
 from .rankings import vlr_rankings
 from .stats import vlr_stats
-from .matches import vlr_upcoming_matches, vlr_live_score, vlr_match_results
+from .matches import vlr_upcoming_matches, vlr_live_score, vlr_match_results, vlr_upcoming_matches_extended
 from .events import vlr_events
 from .health import check_health

--- a/routers/vlr_router.py
+++ b/routers/vlr_router.py
@@ -78,10 +78,11 @@ async def VLR_match(
 ):
     """
     query parameters:\n
-        "upcoming": upcoming matches,\n
+        "upcoming": upcoming matches (from homepage),\n
+        "upcoming_extended": upcoming matches (from paginated /matches page),\n
         "live_score": live match scores,\n
         "results": match results,\n
-    
+
     Page Range Options:
     - num_pages: Number of pages from page 1 (ignored if from_page/to_page specified)
     - from_page: Starting page number (1-based, optional)
@@ -93,12 +94,15 @@ async def VLR_match(
     - timeout: Request timeout in seconds (10-120, default: 30)
     
     Examples:
+    - /match?q=upcoming_extended&num_pages=3 (scrapes pages 1-3 of upcoming matches)
     - /match?q=results&num_pages=5 (scrapes pages 1-5)
     - /match?q=results&from_page=10&to_page=15 (scrapes pages 10-15)
     - /match?q=results&from_page=5&num_pages=3 (scrapes pages 5-7)
     """
     if q == "upcoming":
         return vlr.vlr_upcoming_matches(num_pages, from_page, to_page)
+    elif q == "upcoming_extended":
+        return vlr.vlr_upcoming_matches_extended(num_pages, from_page, to_page, max_retries, request_delay, timeout)
     elif q == "live_score":
         return vlr.vlr_live_score(num_pages, from_page, to_page)
     elif q == "results":


### PR DESCRIPTION
Noticed that the upcoming matches route accepts paginated query params, but aren't actually used because the matches come from the main page. I've added an "extended" upcoming matches route that fetches and scrapes the /matches page from vlr.gg. 