### PR TITLE
Merge PR #163: /stats revamp fixes + empty-page warning follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,10 @@ GET /v2/rankings?region=na
 ### `GET /v2/stats`
 **Params:** `region` (required), `timespan` (required: 30/60/90/all) | **Cache:** 30 min
 
+**Regions** (the `/stats` page taxonomy, distinct from `/rankings`): `all`, `americas`, `emea`, `pacific`, `china`, `intl`. Deprecated aliases are still accepted and normalized: `na`/`br` → `americas`, `eu` → `emea`, `ap`/`kr`/`jp`/`oce` → `pacific`, `cn` → `china`.
+
 ```
-GET /v2/stats?region=na&timespan=30
+GET /v2/stats?region=americas&timespan=30
 ```
 
 <details><summary>Response</summary>
@@ -620,7 +622,7 @@ Preserved for backwards compatibility. Most return `{"data": {"status": int, "se
 </details>
 
 <details>
-<summary><code>GET /stats?region=na&timespan=30</code> — response example</summary>
+<summary><code>GET /stats?region=americas&timespan=30</code> — response example</summary>
 
 ```json
 {

--- a/api/scrapers/stats.py
+++ b/api/scrapers/stats.py
@@ -1,11 +1,14 @@
+import asyncio
 import logging
+
+from fastapi import HTTPException
 
 from utils.cache_manager import cache_manager
 from utils.constants import CACHE_TTL_STATS, VLR_STATS_URL
 from utils.error_handling import (
     handle_scraper_errors,
     raise_for_upstream_status,
-    validate_region,
+    validate_stats_region,
     validate_timespan,
 )
 from utils.html_parsers import extract_text_content, parse_html
@@ -13,21 +16,104 @@ from utils.http_client import fetch_with_retries, get_http_client
 
 logger = logging.getLogger(__name__)
 
+# vlr.gg emits stable, semantic ``data-col`` attributes on every stats <th> except
+# the unlabelled player column. Read cells BY KEY (never by literal index) so a
+# future inserted column can never shift the mapping — the positional fragility
+# fixed here has broken this scraper three times (upstream issues #4 and #14, both
+# "vlr.gg added a column", each re-hardcoded to the new numbers).
+_STATS_FIELD_MAP = {
+    "rnd": "rounds_played",
+    "rating2": "rating",
+    "acs": "average_combat_score",
+    "kd": "kill_deaths",
+    "kast": "kill_assists_survived_traded",
+    "adr": "average_damage_per_round",
+    "kpr": "kills_per_round",
+    "apr": "assists_per_round",
+    "fbpr": "first_kills_per_round",
+    "fdpr": "first_deaths_per_round",
+    "hsp": "headshot_percentage",
+    "clp": "clutch_success_percentage",
+    "cl": "clutch_attempts",
+}
 
-def _cell_text(cells: list, index: int) -> str:
-    """Read a table cell by index without raising on sparse rows."""
-    if index >= len(cells):
+# If <thead> is keyed (>=1 data-col) but any of these is absent, the layout changed
+# in a way we cannot safely parse -> fail closed rather than emit a keyed ``None``
+# that would surface downstream as rating=0 and slip past shape guards.
+REQUIRED_STATS_KEYS = frozenset({"rnd", "rating2", "acs", "kd", "adr"})
+
+# Legacy positional indices, used ONLY when <thead> emits no data-col attributes at
+# all (pre-revamp markup / archived pages). Player is td[0], agents td[1].
+_LEGACY_STATS_INDICES = {
+    "rounds_played": 2,
+    "rating": 3,
+    "average_combat_score": 4,
+    "kill_deaths": 5,
+    "kill_assists_survived_traded": 6,
+    "average_damage_per_round": 7,
+    "kills_per_round": 8,
+    "assists_per_round": 9,
+    "first_kills_per_round": 10,
+    "first_deaths_per_round": 11,
+    "headshot_percentage": 12,
+    "clutch_success_percentage": 13,
+    "clutch_attempts": 14,
+}
+
+# Session priming state. vlr.gg binds /stats filter state to a ``PHPSESSID`` cookie:
+# the FIRST request on a cold client returns the unfiltered global list regardless
+# of ``region=``. The singleton httpx.AsyncClient shares cookies across concurrent
+# requests, so the one-time prime is guarded by a lock + module flag.
+_prime_lock = asyncio.Lock()
+_primed = False
+
+
+def _cell_text(cells: list, index: int | None) -> str:
+    """Read a table cell by index without raising on sparse rows or missing keys."""
+    if index is None or index >= len(cells):
         return ""
     return extract_text_content(cells[index])
 
 
-def _parse_stats_row(item) -> dict:
-    """Parse one stats table row using table-cell structure, not flattened text."""
+def _build_column_map(html) -> dict | None:
+    """Map each <thead> ``data-col`` attribute to its 0-based column index.
+
+    Returns ``{data-col: index}`` when the header is keyed, or ``None`` when it
+    carries no data-col attributes (old markup -> positional fallback). Indices are
+    counted across all <th>, so they line up with the row's <td> positions; the
+    player <th> is unlabelled and is simply absent from the map.
+    """
+    header = html.css_first("thead tr")
+    if header is None:
+        return None
+    col_map: dict[str, int] = {}
+    for index, th in enumerate(header.css("th")):
+        data_col = th.attributes.get("data-col")
+        if data_col:
+            col_map[data_col] = index
+    return col_map or None
+
+
+def _parse_stats_row(item, col_map: dict | None = None) -> dict:
+    """Parse one stats table row.
+
+    With ``col_map`` (from :func:`_build_column_map`) cells are read by semantic
+    ``data-col`` key; without it, the legacy positional indices are used. The player
+    cell is always positional ``td[0]``. The org selector tries the new
+    ``.st-pl-country`` class first and falls back to the pre-revamp
+    ``.stats-player-country`` so either markup parses.
+    """
     cells = item.css("td")
     player_cell = item.css_first("td.mod-player")
 
     player_name = extract_text_content(player_cell.css_first(".text-of")) if player_cell else ""
-    org = extract_text_content(player_cell.css_first(".stats-player-country")) if player_cell else ""
+    org_cell = None
+    if player_cell:
+        org_cell = (
+            player_cell.css_first(".st-pl-country")
+            or player_cell.css_first(".stats-player-country")
+        )
+    org = extract_text_content(org_cell) if org_cell else ""
     if not org:
         org = "N/A"
 
@@ -38,32 +124,66 @@ def _parse_stats_row(item) -> dict:
             continue
         agents.append(src.split("/")[-1].split(".")[0])
 
-    return {
-        "player": player_name,
-        "org": org,
-        "agents": agents,
-        "rounds_played": _cell_text(cells, 2),
-        "rating": _cell_text(cells, 3),
-        "average_combat_score": _cell_text(cells, 4),
-        "kill_deaths": _cell_text(cells, 5),
-        "kill_assists_survived_traded": _cell_text(cells, 6),
-        "average_damage_per_round": _cell_text(cells, 7),
-        "kills_per_round": _cell_text(cells, 8),
-        "assists_per_round": _cell_text(cells, 9),
-        "first_kills_per_round": _cell_text(cells, 10),
-        "first_deaths_per_round": _cell_text(cells, 11),
-        "headshot_percentage": _cell_text(cells, 12),
-        "clutch_success_percentage": _cell_text(cells, 13),
-        "clutch_attempts": _cell_text(cells, 14),
-    }
+    row = {"player": player_name, "org": org, "agents": agents}
+    if col_map is not None:
+        for data_col, out_key in _STATS_FIELD_MAP.items():
+            row[out_key] = _cell_text(cells, col_map.get(data_col))
+    else:
+        for out_key, index in _LEGACY_STATS_INDICES.items():
+            row[out_key] = _cell_text(cells, index)
+    return row
+
+
+def _selected_region(html) -> str | None:
+    """Return the selected <option> value of ``select[name=region]``.
+
+    This is the ground truth of which filter vlr.gg actually applied: the page
+    always echoes the applied region as its selected option. Returns ``None`` when
+    the select is absent so callers can skip response validation on markup they do
+    not model.
+    """
+    select = html.css_first('select[name="region"]')
+    if select is None:
+        return None
+    selected = select.css_first("option[selected]")
+    if selected is None:
+        return None
+    value = selected.attributes.get("value")
+    return value if value is not None else (extract_text_content(selected) or None)
+
+
+async def _fetch_stats_page(client, url: str) -> tuple[int, object]:
+    """Fetch the stats page, raising on an upstream error status; return (status, tree)."""
+    resp = await fetch_with_retries(url, client=client)
+    raise_for_upstream_status(resp.status_code, "stats")
+    return resp.status_code, parse_html(resp.text)
+
+
+async def _prime_session(client, *, force: bool = False) -> None:
+    """Issue one throwaway GET to the /stats page so vlr.gg sets ``PHPSESSID``.
+
+    Guarded by a lock + module flag so the singleton client primes once per boot,
+    not once per call. Raises on failure — a cold response must never be fetched
+    (and cached for ``CACHE_TTL_STATS`` seconds) unfiltered. ``force=True`` re-primes
+    after a detected region mismatch.
+    """
+    global _primed
+    async with _prime_lock:
+        if _primed and not force:
+            return
+        resp = await fetch_with_retries(f"{VLR_STATS_URL}/", client=client)
+        raise_for_upstream_status(resp.status_code, "stats prime")
+        _primed = True
 
 
 @handle_scraper_errors
 async def vlr_stats(region_key: str, timespan: str):
-    async def build():
-        validate_region(region_key)
-        validate_timespan(timespan)
+    # Normalize alias -> canonical BEFORE the cache key is formed so na and americas
+    # resolve to one entry, and validate up front so bad input fails without a fetch.
+    region_key = validate_stats_region(region_key)
+    validate_timespan(timespan)
 
+    async def build():
         base_url = (
             f"{VLR_STATS_URL}/?event_group_id=all&event_id=all"
             f"&region={region_key}&country=all&min_rounds=200"
@@ -76,21 +196,57 @@ async def vlr_stats(region_key: str, timespan: str):
         )
 
         client = get_http_client()
-        resp = await fetch_with_retries(url, client=client)
-        status = resp.status_code
-        raise_for_upstream_status(status, "stats")
+        await _prime_session(client)
 
-        html = parse_html(resp.text)
+        status, html = await _fetch_stats_page(client, url)
+
+        # Response-level validation is the correctness signal (not cookie presence):
+        # the page echoes the applied filter as its selected region option. On a
+        # mismatch, re-prime and refetch once; a second mismatch means vlr.gg is
+        # ignoring region= -> raise rather than cache a globally-scoped list under a
+        # specific region key.
+        selected = _selected_region(html)
+        if selected is not None and selected != region_key:
+            logger.warning(
+                "VLR.GG /stats applied region '%s' but '%s' was requested; re-priming",
+                selected, region_key,
+            )
+            await _prime_session(client, force=True)
+            status, html = await _fetch_stats_page(client, url)
+            selected = _selected_region(html)
+            if selected is not None and selected != region_key:
+                raise HTTPException(
+                    status_code=502,
+                    detail=(
+                        f"VLR.GG /stats ignored the region filter: requested "
+                        f"'{region_key}', page applied '{selected}'"
+                    ),
+                )
+
+        col_map = _build_column_map(html)
+        if col_map is not None:
+            missing = REQUIRED_STATS_KEYS - col_map.keys()
+            if missing:
+                raise HTTPException(
+                    status_code=502,
+                    detail=(
+                        "VLR.GG /stats column layout changed: required columns "
+                        f"{sorted(missing)} missing from header"
+                    ),
+                )
+        else:
+            logger.warning(
+                "VLR.GG /stats header has no data-col attributes; "
+                "falling back to legacy positional column indices"
+            )
 
         result = []
         for item in html.css("tbody tr"):
-            parsed = _parse_stats_row(item)
+            parsed = _parse_stats_row(item, col_map)
             if parsed["player"]:
                 result.append(parsed)
 
-        data = {"data": {"status": status, "segments": result}}
-
-        return data
+        return {"data": {"status": status, "segments": result}}
 
     return await cache_manager.get_or_create_async(
         CACHE_TTL_STATS, build, "stats", region_key, timespan

--- a/api/scrapers/stats.py
+++ b/api/scrapers/stats.py
@@ -234,7 +234,10 @@ async def vlr_stats(region_key: str, timespan: str):
                         f"{sorted(missing)} missing from header"
                     ),
                 )
-        else:
+        elif html.css_first("table") is not None:
+            # A table without data-col attributes is genuinely legacy markup. A page
+            # with NO table at all is a legitimately-empty result set (vlr.gg renders
+            # no table for zero rows, e.g. sparse tier/span windows) — stay quiet.
             logger.warning(
                 "VLR.GG /stats header has no data-col attributes; "
                 "falling back to legacy positional column indices"

--- a/routers/v2_router.py
+++ b/routers/v2_router.py
@@ -59,7 +59,7 @@ async def v2_news():
 
 @router.get("/stats", response_model=V2Response, summary="Player stats", description="Get player statistics for a region and timespan.")
 async def v2_stats(
-    region: str = Query(..., description="Region shortname (na, eu, ap, la, la-s, la-n, oce, kr, mn, gc, br, cn, jp, col)"),
+    region: str = Query(..., description="Region: all, americas, emea, pacific, china, intl (deprecated aliases: na/br -> americas, eu -> emea, ap/kr/jp/oce -> pacific, cn -> china)"),
     timespan: str = Query(..., description="Timespan: 30, 60, 90, or all"),
 ):
     result = await get_stats_data(region, timespan)

--- a/routers/vlr_router.py
+++ b/routers/vlr_router.py
@@ -59,20 +59,19 @@ async def VLR_news():
 
 @router.get("/stats")
 async def VLR_stats(
-    region: str = Query(..., description="Region shortname"),
+    region: str = Query(..., description="Region: all, americas, emea, pacific, china, intl (deprecated aliases accepted)"),
     timespan: str = Query(..., description="Timespan (30, 60, 90, or all)"),
 ):
     """
     Get VLR stats with query parameters.
 
-    region shortnames:\n
-        "na": "north-america",\n
-        "eu": "europe",\n
-        "ap": "asia-pacific",\n
-        "sa": "latin-america",\n
-        "jp": "japan",\n
-        "oce": "oceania",\n
-        "mn": "mena"\n
+    regions (the /stats page taxonomy — differs from /rankings):\n
+        all | americas | emea | pacific | china | intl\n
+    deprecated aliases (normalized):\n
+        na, br -> americas\n
+        eu -> emea\n
+        ap, kr, jp, oce -> pacific\n
+        cn -> china\n
     """
     return await get_stats_data(region, timespan)
 

--- a/tests/test_stats_scraper.py
+++ b/tests/test_stats_scraper.py
@@ -436,6 +436,22 @@ async def test_empty_region_returns_no_error_no_retry(monkeypatch):
     assert len(fetch.calls) == 2
 
 
+@pytest.mark.anyio
+async def test_tableless_empty_page_returns_empty_without_fallback_warning(monkeypatch, caplog):
+    """vlr.gg renders NO table at all for a zero-row result (e.g. sparse tier/span
+    windows). That is an empty result set, not legacy markup — no fallback warning."""
+    fetch = _install_fake_fetch(monkeypatch)
+    fetch.page_for_region = lambda region: (
+        f"<html><body>{_region_select(selected=region)}</body></html>"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="api.scrapers.stats"):
+        data = await vlr_stats("americas", "60")
+
+    assert data["data"]["segments"] == []
+    assert not any("no data-col" in rec.message for rec in caplog.records)
+
+
 # ---------------------------------------------------------------------------
 # Region vocabulary
 # ---------------------------------------------------------------------------

--- a/tests/test_stats_scraper.py
+++ b/tests/test_stats_scraper.py
@@ -1,9 +1,25 @@
+import logging
+import re
+
 import pytest
+from fastapi import HTTPException
 from selectolax.parser import HTMLParser
 
-from api.scrapers.stats import _parse_stats_row, vlr_stats
+import api.scrapers.stats as stats_mod
+from api.scrapers.stats import (
+    _build_column_map,
+    _parse_stats_row,
+    _selected_region,
+    vlr_stats,
+)
 from utils.cache_manager import cache_manager
+from utils.error_handling import validate_region
 
+# ---------------------------------------------------------------------------
+# Legacy (pre-revamp) 21-ish column markup: NO data-col attributes, org lives in
+# .stats-player-country. Cells are laid out at the historical positional indices
+# (player td[0], agents td[1], then rnd td[2], rating td[3], acs td[4] ...).
+# ---------------------------------------------------------------------------
 STATS_HTML = """
 <html>
   <table>
@@ -38,6 +54,70 @@ STATS_HTML = """
 </html>
 """
 
+# The full ordered list of data-col attributes vlr.gg now emits (after the player
+# column, which is unlabelled). 22 keyed columns == 23 <th> including player.
+NEW_DATA_COLS = [
+    "agents", "maps", "rnd", "rating2", "acs", "kd", "kast", "adr", "kpr", "apr",
+    "fkfd", "fbpr", "fdpr", "hsp", "clp", "cl", "kmax", "k", "d", "a", "fk", "fd",
+]
+
+# Realistic per-column cell text for one row.
+NEW_ROW_VALUES = {
+    "maps": "11", "rnd": "228", "rating2": "1.37", "acs": "247", "kd": "1.15",
+    "kast": "73%", "adr": "155.0", "kpr": "0.82", "apr": "0.30", "fkfd": "+5",
+    "fbpr": "0.14", "fdpr": "0.10", "hsp": "28%", "clp": "20%", "cl": "7/35",
+    "kmax": "30", "k": "180", "d": "150", "a": "60", "fk": "25", "fd": "20",
+}
+
+STATS_REGION_OPTIONS = ["all", "americas", "emea", "pacific", "china", "intl"]
+
+
+def _thead(data_cols=NEW_DATA_COLS, drop=()):
+    """Build a <thead> with a data-col on each column except those in ``drop``."""
+    ths = ['<th class="mod-player">Player</th>']
+    for col in data_cols:
+        if col in drop:
+            ths.append(f"<th>{col}</th>")  # present but unkeyed
+        else:
+            ths.append(f'<th data-col="{col}">{col}</th>')
+    return "<thead><tr>" + "".join(ths) + "</tr></thead>"
+
+
+def _new_row(values=None, org="NRG", player="brawk", org_class="st-pl-country"):
+    """Build a <tr> whose <td> order matches NEW_DATA_COLS (player first)."""
+    values = values if values is not None else NEW_ROW_VALUES
+    tds = [
+        f'<td class="mod-player"><a><div class="text-of">{player}</div>'
+        f'<div class="{org_class}">{org}</div></a></td>'
+    ]
+    for col in NEW_DATA_COLS:
+        if col == "agents":
+            tds.append('<td class="mod-agents"><img src="/img/vlr/game/agents/jett.png"></td>')
+        else:
+            tds.append(f"<td>{values.get(col, '')}</td>")
+    return "<tr>" + "".join(tds) + "</tr>"
+
+
+def _region_select(selected="americas"):
+    opts = []
+    for r in STATS_REGION_OPTIONS:
+        sel = " selected" if r == selected else ""
+        opts.append(f'<option value="{r}"{sel}>{r}</option>')
+    return '<select name="region">' + "".join(opts) + "</select>"
+
+
+def make_stats_page(selected="americas", rows=None, thead=None, include_select=True):
+    """Assemble a full new-markup /stats page for the vlr_stats flow tests."""
+    if thead is None:
+        thead = _thead()
+    if rows is None:
+        rows = _new_row()
+    select_html = _region_select(selected) if include_select else ""
+    return (
+        f"<html><body>{select_html}"
+        f"<table>{thead}<tbody>{rows}</tbody></table></body></html>"
+    )
+
 
 class FakeResponse:
     def __init__(self, status_code: int, text: str):
@@ -47,17 +127,60 @@ class FakeResponse:
         self.headers: dict = {}
 
 
-class FakeAsyncClient:
-    def __init__(self, response: FakeResponse):
-        self.response = response
-        self.calls: list[tuple[str, int | None]] = []
-
-    async def get(self, url: str, timeout=None, headers=None):
-        self.calls.append((url, timeout))
-        return self.response
+def _region_of(url: str) -> str | None:
+    """Extract the region= query value from a /stats URL. None => a prime GET."""
+    match = re.search(r"[?&]region=([^&]+)", url)
+    return match.group(1) if match else None
 
 
-def test_parse_stats_row_uses_structured_player_and_org_selectors():
+class FakeFetch:
+    """Stand-in for fetch_with_retries: routes prime vs data requests by URL.
+
+    A URL with no ``region=`` is the priming GET. Data URLs get a page whose
+    selected region echoes the requested one, unless ``selected_override`` forces a
+    different (mismatched) region to simulate D4 poisoning.
+    """
+
+    def __init__(self):
+        self.calls: list[str] = []
+        self.prime_status = 200
+        self.selected_override: str | None = None
+        self.page_for_region = None  # optional callable(region) -> html
+
+    async def __call__(self, url, *, client=None, **kwargs):
+        self.calls.append(url)
+        region = _region_of(url)
+        if region is None:
+            return FakeResponse(self.prime_status, "<html><body>primed</body></html>")
+        if self.page_for_region is not None:
+            return FakeResponse(200, self.page_for_region(region))
+        selected = self.selected_override or region
+        return FakeResponse(200, make_stats_page(selected=selected))
+
+
+@pytest.fixture(autouse=True)
+def _reset_stats_state():
+    """Each test starts cold: empty cache and an unprimed session."""
+    cache_manager.clear_all()
+    stats_mod._primed = False
+    yield
+    cache_manager.clear_all()
+    stats_mod._primed = False
+
+
+def _install_fake_fetch(monkeypatch) -> FakeFetch:
+    fetch = FakeFetch()
+    monkeypatch.setattr("api.scrapers.stats.fetch_with_retries", fetch)
+    monkeypatch.setattr("api.scrapers.stats.get_http_client", lambda: object())
+    return fetch
+
+
+# ---------------------------------------------------------------------------
+# Row / column-map parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_stats_row_legacy_positional_fallback():
+    """Old 21-column markup (no data-col, .stats-player-country) still parses."""
     row = HTMLParser(STATS_HTML).css_first("tbody tr")
 
     assert _parse_stats_row(row) == {
@@ -80,44 +203,280 @@ def test_parse_stats_row_uses_structured_player_and_org_selectors():
     }
 
 
+def test_parse_stats_row_new_markup_header_keyed():
+    """23-column markup: cells read by data-col key, immune to inserted columns."""
+    tree = HTMLParser(make_stats_page(include_select=False))
+    col_map = _build_column_map(tree)
+    row = tree.css_first("tbody tr")
+
+    parsed = _parse_stats_row(row, col_map)
+
+    assert parsed["rounds_played"] == "228"
+    assert parsed["rating"] == "1.37"
+    assert parsed["average_combat_score"] == "247"
+    assert parsed["org"] == "NRG"
+    # clutch_attempts must come from the ``cl`` key, not a positional index.
+    assert parsed["clutch_attempts"] == "7/35"
+    # the inserted ``maps`` column must NOT leak into rounds_played.
+    assert parsed["rounds_played"] != "11"
+
+
+def test_build_column_map_keys_align_with_td_positions():
+    tree = HTMLParser(make_stats_page(include_select=False))
+    col_map = _build_column_map(tree)
+
+    # player is td[0] (unkeyed), agents td[1], maps td[2], rnd td[3] ...
+    assert col_map["agents"] == 1
+    assert col_map["maps"] == 2
+    assert col_map["rnd"] == 3
+    assert col_map["rating2"] == 4
+    assert col_map["acs"] == 5
+    assert col_map["cl"] == 16
+
+
+def test_build_column_map_none_for_legacy_markup():
+    tree = HTMLParser(STATS_HTML)
+    assert _build_column_map(tree) is None
+
+
+# ---------------------------------------------------------------------------
+# Org selector fallback (D2)
+# ---------------------------------------------------------------------------
+
+def test_org_selector_prefers_new_class():
+    html = (
+        '<table><tbody><tr><td class="mod-player"><a>'
+        '<div class="text-of">p</div>'
+        '<div class="st-pl-country">NRG</div>'
+        '<div class="stats-player-country">OLD</div>'
+        '</a></td></tr></tbody></table>'
+    )
+    row = HTMLParser(html).css_first("tbody tr")
+    assert _parse_stats_row(row)["org"] == "NRG"
+
+
+def test_org_selector_falls_back_to_old_class():
+    html = (
+        '<table><tbody><tr><td class="mod-player"><a>'
+        '<div class="text-of">p</div>'
+        '<div class="stats-player-country">VIT</div>'
+        '</a></td></tr></tbody></table>'
+    )
+    row = HTMLParser(html).css_first("tbody tr")
+    assert _parse_stats_row(row)["org"] == "VIT"
+
+
+def test_org_selector_missing_defaults_na():
+    html = (
+        '<table><tbody><tr><td class="mod-player"><a>'
+        '<div class="text-of">p</div></a></td></tr></tbody></table>'
+    )
+    row = HTMLParser(html).css_first("tbody tr")
+    assert _parse_stats_row(row)["org"] == "N/A"
+
+
+# ---------------------------------------------------------------------------
+# Full vlr_stats flow
+# ---------------------------------------------------------------------------
+
 @pytest.mark.anyio
-async def test_vlr_stats_preserves_output_shape_with_structured_row_parsing(monkeypatch):
-    cache_manager.clear_all()
-    client = FakeAsyncClient(FakeResponse(200, STATS_HTML))
+async def test_vlr_stats_new_markup_end_to_end(monkeypatch):
+    fetch = _install_fake_fetch(monkeypatch)
 
-    monkeypatch.setattr("api.scrapers.stats.get_http_client", lambda: client)
+    data = await vlr_stats("americas", "60")
 
-    data = await vlr_stats("na", "30")
-
-    assert data == {
-        "data": {
-            "status": 200,
-            "segments": [
-                {
-                    "player": "TenZ Prime",
-                    "org": "Team Liquid",
-                    "agents": ["jett", "omen"],
-                    "rounds_played": "442",
-                    "rating": "1.36",
-                    "average_combat_score": "248.4",
-                    "kill_deaths": "1.58",
-                    "kill_assists_survived_traded": "79%",
-                    "average_damage_per_round": "158.5",
-                    "kills_per_round": "0.90",
-                    "assists_per_round": "0.36",
-                    "first_kills_per_round": "0.07",
-                    "first_deaths_per_round": "0.05",
-                    "headshot_percentage": "33%",
-                    "clutch_success_percentage": "16%",
-                    "clutch_attempts": "9/57",
-                }
-            ],
-        }
+    seg = data["data"]["segments"]
+    assert len(seg) == 1
+    assert seg[0]["rounds_played"] == "228"
+    assert seg[0]["rating"] == "1.37"
+    assert seg[0]["average_combat_score"] == "247"
+    assert seg[0]["org"] == "NRG"
+    assert seg[0]["clutch_attempts"] == "7/35"
+    # output key set is unchanged from upstream's contract
+    assert set(seg[0].keys()) == {
+        "player", "org", "agents", "rounds_played", "rating",
+        "average_combat_score", "kill_deaths", "kill_assists_survived_traded",
+        "average_damage_per_round", "kills_per_round", "assists_per_round",
+        "first_kills_per_round", "first_deaths_per_round", "headshot_percentage",
+        "clutch_success_percentage", "clutch_attempts",
     }
-    assert client.calls == [
-        (
-            "https://www.vlr.gg/stats/?event_group_id=all&event_id=all&region=na&country=all&min_rounds=200&min_rating=1550&agent=all&map_id=all&timespan=30d",
-            None,
-        )
-    ]
-    cache_manager.clear_all()
+    # prime fired first, exactly once, before the data fetch
+    assert _region_of(fetch.calls[0]) is None
+    assert "region=americas" in fetch.calls[1]
+
+
+@pytest.mark.anyio
+async def test_vlr_stats_legacy_markup_logs_warning(monkeypatch, caplog):
+    fetch = _install_fake_fetch(monkeypatch)
+    # legacy page: positional cells, no data-col, no region select (skip validation)
+    legacy_thead = "<thead><tr><th>Player</th><th>Agents</th><th>Rnd</th></tr></thead>"
+    legacy_tbody = HTMLParser(STATS_HTML).css_first("tbody").html
+    legacy_page = f"<html><body><table>{legacy_thead}{legacy_tbody}</table></body></html>"
+    fetch.page_for_region = lambda region: legacy_page
+
+    with caplog.at_level(logging.WARNING, logger="api.scrapers.stats"):
+        data = await vlr_stats("americas", "60")
+
+    seg = data["data"]["segments"]
+    assert seg[0]["rounds_played"] == "442"
+    assert seg[0]["rating"] == "1.36"
+    assert seg[0]["org"] == "Team Liquid"
+    assert any("no data-col" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_vlr_stats_missing_required_key_raises(monkeypatch):
+    fetch = _install_fake_fetch(monkeypatch)
+    # data-col present on most columns, but rating2 is unkeyed -> must fail closed
+    page = make_stats_page(thead=_thead(drop=("rating2",)))
+    fetch.page_for_region = lambda region: page
+
+    with pytest.raises(HTTPException) as exc:
+        await vlr_stats("americas", "60")
+    assert exc.value.status_code == 502
+    # nothing partial-parsed reached the cache
+    assert cache_manager.get(stats_mod.CACHE_TTL_STATS, "stats", "americas", "60") is None
+
+
+@pytest.mark.anyio
+async def test_priming_fires_once_across_two_region_calls(monkeypatch):
+    fetch = _install_fake_fetch(monkeypatch)
+
+    await vlr_stats("americas", "60")
+    await vlr_stats("emea", "60")
+
+    prime_calls = [c for c in fetch.calls if _region_of(c) is None]
+    assert len(prime_calls) == 1
+    # order: prime, then the two data fetches
+    assert _region_of(fetch.calls[0]) is None
+    assert "region=americas" in fetch.calls[1]
+    assert "region=emea" in fetch.calls[2]
+
+
+@pytest.mark.anyio
+async def test_failing_prime_raises_and_caches_nothing(monkeypatch):
+    fetch = _install_fake_fetch(monkeypatch)
+    fetch.prime_status = 503
+
+    with pytest.raises(HTTPException) as exc:
+        await vlr_stats("americas", "60")
+    assert exc.value.status_code == 503
+    # only the prime was attempted; no data fetch, nothing cached
+    assert all(_region_of(c) is None for c in fetch.calls)
+    assert cache_manager.get(stats_mod.CACHE_TTL_STATS, "stats", "americas", "60") is None
+    assert stats_mod._primed is False
+
+
+@pytest.mark.anyio
+async def test_region_mismatch_retries_then_raises(monkeypatch):
+    fetch = _install_fake_fetch(monkeypatch)
+    fetch.selected_override = "all"  # page always claims the global list
+
+    with pytest.raises(HTTPException) as exc:
+        await vlr_stats("americas", "60")
+    assert exc.value.status_code == 502
+
+    # one prime, one data fetch, one FORCED re-prime, one refetch
+    prime_calls = [c for c in fetch.calls if _region_of(c) is None]
+    data_calls = [c for c in fetch.calls if _region_of(c) is not None]
+    assert len(prime_calls) == 2
+    assert len(data_calls) == 2
+    # the mismatched response was never cached
+    assert cache_manager.get(stats_mod.CACHE_TTL_STATS, "stats", "americas", "60") is None
+
+
+@pytest.mark.anyio
+async def test_region_mismatch_recovers_on_reprime(monkeypatch):
+    """A mismatch on the first fetch that clears after a re-prime succeeds."""
+    fetch = _install_fake_fetch(monkeypatch)
+    state = {"first": True}
+
+    def builder(region):
+        if state["first"]:
+            state["first"] = False
+            return make_stats_page(selected="all")  # cold/global on first data fetch
+        return make_stats_page(selected=region)
+
+    fetch.page_for_region = builder
+
+    data = await vlr_stats("americas", "60")
+    assert data["data"]["segments"][0]["org"] == "NRG"
+
+
+@pytest.mark.anyio
+async def test_alias_normalizes_before_cache_key(monkeypatch):
+    fetch = _install_fake_fetch(monkeypatch)
+
+    await vlr_stats("na", "60")
+
+    # cache entry is keyed on the canonical region, not the alias
+    assert cache_manager.get(stats_mod.CACHE_TTL_STATS, "stats", "americas", "60") is not None
+    assert cache_manager.get(stats_mod.CACHE_TTL_STATS, "stats", "na", "60") is None
+    # the fetched URL carries the canonical region
+    data_calls = [c for c in fetch.calls if _region_of(c) is not None]
+    assert "region=americas" in data_calls[0]
+
+    # a follow-up canonical request is served from the same cache entry (no refetch)
+    before = len(fetch.calls)
+    await vlr_stats("americas", "60")
+    assert len(fetch.calls) == before
+
+
+@pytest.mark.anyio
+async def test_empty_region_returns_no_error_no_retry(monkeypatch):
+    fetch = _install_fake_fetch(monkeypatch)
+    # correct selected region, zero rows
+    fetch.page_for_region = lambda region: make_stats_page(selected=region, rows="")
+
+    data = await vlr_stats("pacific", "60")
+
+    assert data["data"]["segments"] == []
+    assert data["data"]["status"] == 200
+    # exactly one prime + one data fetch, no retry
+    assert len(fetch.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Region vocabulary
+# ---------------------------------------------------------------------------
+
+def test_selected_region_reads_selected_option():
+    tree = HTMLParser(make_stats_page(selected="emea"))
+    assert _selected_region(tree) == "emea"
+
+
+def test_selected_region_none_when_absent():
+    tree = HTMLParser("<html><body><table></table></body></html>")
+    assert _selected_region(tree) is None
+
+
+@pytest.mark.parametrize("value", ["americas", "all", "intl"])
+def test_validate_stats_region_accepts_canonical(value):
+    from utils.error_handling import validate_stats_region
+    assert validate_stats_region(value) == value
+
+
+@pytest.mark.parametrize(
+    "alias,canonical",
+    [("na", "americas"), ("br", "americas"), ("eu", "emea"),
+     ("ap", "pacific"), ("kr", "pacific"), ("jp", "pacific"),
+     ("oce", "pacific"), ("cn", "china")],
+)
+def test_validate_stats_region_normalizes_aliases(alias, canonical):
+    from utils.error_handling import validate_stats_region
+    assert validate_stats_region(alias) == canonical
+
+
+@pytest.mark.parametrize("value", ["la", "la-s", "la-n", "mn", "gc", "col", "xyz"])
+def test_validate_stats_region_rejects_unknown(value):
+    from utils.error_handling import validate_stats_region
+    with pytest.raises(HTTPException) as exc:
+        validate_stats_region(value)
+    assert exc.value.status_code == 400
+
+
+def test_rankings_region_americas_still_400():
+    """The shared /rankings region dict is untouched: 'americas' must still 400."""
+    with pytest.raises(HTTPException) as exc:
+        validate_region("americas")
+    assert exc.value.status_code == 400

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -68,3 +68,10 @@ CACHE_TTL_TEAM_TRANSACTIONS = 3600
 CACHE_TTL_TEAM_STATS = 600
 CACHE_TTL_EVENT_MATCHES = 600
 CACHE_TTL_HEALTH_UPSTREAM = 60
+
+# /stats region vocabulary
+# The /stats page uses a DIFFERENT region taxonomy from /rankings. vlr.gg's
+# <select name="region"> offers exactly these canonical values; any other value
+# silently falls back to "all". Kept separate from utils.utils.region (the
+# /rankings contract) so /rankings?region=americas still returns 400.
+STATS_REGIONS = frozenset({"all", "americas", "emea", "pacific", "china", "intl"})

--- a/utils/error_handling.py
+++ b/utils/error_handling.py
@@ -12,6 +12,7 @@ from utils.constants import (
     MAX_MATCH_PAGE_WINDOW,
     MAX_MATCH_RETRIES,
     MAX_MATCH_TIMEOUT,
+    STATS_REGIONS,
 )
 from utils.http_client import CircuitOpenError
 from utils.utils import region
@@ -93,6 +94,42 @@ def validate_region(key: str) -> str:
             detail=f"Invalid region '{key}'. Valid regions: {', '.join(sorted(region.keys()))}",
         )
     return region[key]
+
+
+# Deprecated /stats region aliases -> canonical value. vlr.gg retired the
+# na|eu|ap|... vocabulary on its /stats page (it still applies to /rankings), so
+# these are normalized instead of rejected to keep legacy callers working.
+STATS_REGION_ALIASES = {
+    "na": "americas",
+    "br": "americas",
+    "eu": "emea",
+    "ap": "pacific",
+    "kr": "pacific",
+    "jp": "pacific",
+    "oce": "pacific",
+    "cn": "china",
+}
+
+
+def validate_stats_region(key: str) -> str:
+    """Validate and normalize a /stats region key to its canonical value.
+
+    The /stats page taxonomy (all|americas|emea|pacific|china|intl) differs from
+    /rankings. Legacy /rankings shortnames (na, eu, ap, kr, jp, oce, br, cn) are
+    accepted as deprecated aliases and normalized to their canonical /stats value.
+    Anything else (la, la-s, la-n, mn, gc, col, ...) raises 400. Used ONLY by the
+    /stats path; validate_region remains the /rankings contract.
+    """
+    normalized = STATS_REGION_ALIASES.get(key, key)
+    if normalized not in STATS_REGIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid region '{key}'. Valid regions: "
+                f"{', '.join(sorted(STATS_REGIONS))}"
+            ),
+        )
+    return normalized
 
 
 def validate_timespan(ts: str):


### PR DESCRIPTION
Lands #163 (conflict-resolved against dev's http/scraper refactor 49c3070) plus one follow-up commit.

## Contents
- Merge of #163: header-keyed data-col parsing, .st-pl-country fallback, new /stats region vocabulary with deprecated aliases, PHPSESSID session priming with response-level region validation.
- Follow-up fix(stats): suppress the legacy-fallback warning on table-less pages — vlr.gg renders no table for zero-row results (common with the new tier=vct default), which is an empty result set, not legacy markup.

## Conflict resolution
tests/test_stats_scraper.py: dev's 49c3070 added headers= to FakeAsyncClient.get; #163 deletes FakeAsyncClient entirely (replaced by FakeFetch which stubs fetch_with_retries). Took the #163 side; dev's FakeResponse.content addition retained.

## Verification
- 128/128 tests pass on this branch.
- Verified live against vlr.gg: priming defect reproduced (cold client returns global 100-row page; primed client returns filtered page with region echoed as selected option); emea/90d parses 30 rows with sane values, 0 org=N/A, no column shift; alias na shares the americas cache entry.
- Note: revamp also renamed timespan -> span (old param still honored server-side, verified) and defaults to tier=vct, so /stats results are currently VCT-only. Tracked as upstream drift, out of scope here.