### PR TITLE
fix: strip PICK label from map names

### DIFF
--- a/api/scrapers/match_detail/parsers.py
+++ b/api/scrapers/match_detail/parsers.py
@@ -491,6 +491,7 @@ def _parse_maps(html: HTMLParser) -> list[dict]:
             if not map_name:
                 map_name = map_container.text(strip=True).split("\n")[0].strip()
                 map_name = re.sub(r"\s*\d{1,2}:\d{2}(?::\d{2})?\s*$", "", map_name).strip()
+                map_name = re.sub(r"\s*PICK\s*$", "", map_name, flags=re.IGNORECASE).strip()
 
         duration = ""
         dur_elem = game_elem.css_first(".map-duration")

--- a/tests/test_match_detail_scraper.py
+++ b/tests/test_match_detail_scraper.py
@@ -1,8 +1,10 @@
 import asyncio
 
 import pytest
+from selectolax.parser import HTMLParser
 
 from api.scrapers.match_detail import vlr_match_detail
+from api.scrapers.match_detail.parsers import _parse_maps
 from utils.cache_manager import cache_manager
 
 PLAYER_ROW = """
@@ -63,6 +65,16 @@ BASE_MATCH_HTML = f"""
   </div>
 </html>
 """
+
+
+def test_parse_maps_excludes_pick_label_from_map_name():
+    html = HTMLParser(
+        '<div class="vm-stats-game" data-game-id="game-1">'
+        '<div class="vm-stats-game-header"><div class="map">Summit<span>PICK</span></div></div>'
+        "</div>"
+    )
+
+    assert _parse_maps(html)[0]["map_name"] == "Summit"
 
 
 def performance_html(opponent_name: str) -> str:


### PR DESCRIPTION
Closes #167

VLR's current map markup appends a `PICK` child label to the map container, so fallback text extraction returned names such as `SummitPICK`. Strip that trailing label while preserving the map name.

Tested with the focused regression and the full test suite (129 passed).
